### PR TITLE
Pass the `flatPackage` option from build.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0-pre5",
-  "beyondthelines"         %% "grpcmonixgenerator" % "0.0.1"
+  "beyondthelines"         %% "grpcmonixgenerator" % "0.0.2"
 )
 ```
 
@@ -38,12 +38,12 @@ PB.targets in Compile := Seq(
   // compile your proto files into scala source files
   scalapb.gen() -> (sourceManaged in Compile).value,
   // generate the GRPCMonix source code
-  grpcmonix.generators.GrpcMonixGenerator -> (sourceManaged in Compile).value
+  grpcmonix.generators.GrpcMonixGenerator() -> (sourceManaged in Compile).value
 )
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcmonixruntime" % "0.0.1"
+libraryDependencies += "beyondthelines" %% "grpcmonixruntime" % "0.0.2"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "beyondthelines",
-  version := "0.0.1",
+  version := "0.0.2",
   licenses := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil,
   bintrayOrganization := Some("beyondthelines"),
   bintrayPackageLabels := Seq("scala", "protobuf", "grpc", "monix")

--- a/generator/src/main/scala/grpcmonix/generators/GrpcMonixGenerator.scala
+++ b/generator/src/main/scala/grpcmonix/generators/GrpcMonixGenerator.scala
@@ -5,18 +5,25 @@ import com.google.protobuf.ExtensionRegistry
 import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
 import com.trueaccord.scalapb.Scalapb
 import com.trueaccord.scalapb.compiler.FunctionalPrinter.PrinterEndo
-import com.trueaccord.scalapb.compiler.{DescriptorPimps, FunctionalPrinter, StreamType}
+import com.trueaccord.scalapb.compiler.{DescriptorPimps, FunctionalPrinter, GeneratorParams, StreamType}
 
 import scala.collection.JavaConverters._
 
-object GrpcMonixGenerator extends protocbridge.ProtocCodeGenerator with DescriptorPimps {
+object GrpcMonixGenerator {
 
+  def apply(flatPackage: Boolean = false): GrpcMonixGenerator = {
+    val params = GeneratorParams().copy(flatPackage = flatPackage)
+    new GrpcMonixGenerator(params)
+  }
+}
+
+class GrpcMonixGenerator(override val params: GeneratorParams)
+  extends protocbridge.ProtocCodeGenerator
+  with DescriptorPimps {
   // Read scalapb.options (if present) in .proto files
   override def registerExtensions(registry: ExtensionRegistry): Unit = {
     Scalapb.registerAllExtensions(registry)
   }
-
-  val params = com.trueaccord.scalapb.compiler.GeneratorParams()
 
   def run(request: CodeGeneratorRequest): CodeGeneratorResponse = {
     val b = CodeGeneratorResponse.newBuilder


### PR DESCRIPTION
Pass the `GeneratorParams` in constructor so that `flatPackage` can be specified directly in build.sbt:

```scala
PB.targets in Compile := Seq(
  scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value,
  // generate the reactive (monix) files
  grpcmonix.generators.GrpcMonixGenerator(flatPackage = true) -> (sourceManaged in Compile).value
)
```

Solves https://github.com/btlines/grpcmonix/issues/3