### PR TITLE
Avoid deprecated MethodDescriptor.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
   "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0-pre5",
-  "beyondthelines"         %% "grpcmonixgenerator" % "0.0.4"
+  "beyondthelines"         %% "grpcmonixgenerator" % "0.0.5"
 )
 ```
 
@@ -43,7 +43,7 @@ PB.targets in Compile := Seq(
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "grpcmonixruntime" % "0.0.4"
+libraryDependencies += "beyondthelines" %% "grpcmonixruntime" % "0.0.5"
 ```
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 organization in ThisBuild := "beyondthelines"
-version in ThisBuild := "0.0.4"
+version in ThisBuild := "0.0.5-SNAPSHOT"
 bintrayOrganization in ThisBuild := Some(organization.value)
 bintrayRepository in ThisBuild := "maven"
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc", "monix")


### PR DESCRIPTION
`MethodDescriptor.create` is deprecated in favour of a builder pattern `MethodDescriptor.newBuilder()`