### PR TITLE
Upgrade Monix to 3.0.0-RC1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 target/
 */target/
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val runtime = (project in file("runtime"))
     name := "GrpcMonixRuntime",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapbVersion,
-      "io.monix"             %% "monix"                % "2.3.3"
+      "io.monix"             %% "monix"                % "3.0.0-RC1"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,11 @@ bintrayRepository in ThisBuild := "maven"
 bintrayPackageLabels in ThisBuild := Seq("scala", "protobuf", "grpc", "monix")
 licenses in ThisBuild := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil
 
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 
 lazy val runtime = (project in file("runtime"))
   .settings(
-    crossScalaVersions := Seq("2.12.4", "2.11.11"),
+    crossScalaVersions := Seq("2.12.6", "2.11.11"),
     name := "GrpcMonixRuntime",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapbVersion,
@@ -21,7 +21,7 @@ lazy val runtime = (project in file("runtime"))
 
 lazy val generator = (project in file("generator"))
   .settings(
-    crossScalaVersions := Seq("2.12.4", "2.10.6"),
+    crossScalaVersions := Seq("2.12.6", "2.10.6"),
     name := "GrpcMonixGenerator",
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "compilerplugin"       % scalapbVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.1.1
+sbt.version=1.2.1
 

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.17")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 
 libraryDependencies ++= Seq(
-  "com.thesamet.scalapb" %% "compilerplugin" % "0.7.0"
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 )
 


### PR DESCRIPTION
Hi!

@btlines We would like to use the `grpc-monix` code generator in RChain. However, we need to upgrade it to the current version of Monix. If my changes are ok, could you tag/release version `0.0.8` ASAP?

- [x] Monix 3.0.0-RC1
- [x] scalaPB 0.7.4
- [x] sbt 1.2.1
